### PR TITLE
Update to tor 0.4.7.8

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,8 +6,8 @@ name: default
 # https://cogarius.medium.com/1-3-complete-guide-to-ci-cd-pipelines-with-drone-io-a53daaf28cf6
 globals:
   version: 
-    - &tor_version TOR_VERSION=0.4.7.7
-    - &docker_tags 0.4.7.7
+    - &tor_version TOR_VERSION=0.4.7.8
+    - &docker_tags 0.4.7.8
   repo: &repo svengo/tor
 
   settings: &docker_creds


### PR DESCRIPTION
Info from the developers:

We have released tor 0.4.7.8 earlier today, a new stable version for the
0.4.7.x series containing an important High severity security fix. The
affected tor are only those of the 0.4.7.x series as in from
tor-0.4.7.1-alpha to tor-0.4.7.7.

https://forum.torproject.net/t/stable-release-0-4-7-8/3679

As stated in the announcement (link above), we strongly recommend that
everyone upgrades to 0.4.7.8.