### PR TITLE
Update to alpine 3.18.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.0
+FROM alpine:3.18.2
 
 # Build-time variables
 ARG TOR_VERSION


### PR DESCRIPTION
The Alpine Linux project is pleased to announce the immediate availability of new stable releases:

- [3.18.2](https://git.alpinelinux.org/aports/log/?h=v3.18.2)

Those releases include security fixes for openssl:

- [CVE-2023-1255](https://security.alpinelinux.org/vuln/CVE-2023-1255)
- [CVE-2023-2650](https://security.alpinelinux.org/vuln/CVE-2023-2650)