### PR TITLE
Update to Docker 0.4.8.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18.3
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.6
+ARG TOR_VERSION=0.4.8.7
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Simple docker container for running a tor node.
 
 
 # Supported tags and respective `Dockerfile` links
-* [`0.4.8.7-01`, `latest`](https://github.com/svengo/docker-tor/blob/bfb9fc1a81e589748a4e94d675733d23954ff6a6/Dockerfile)
+* [`0.4.8.7-1`, `latest`](https://github.com/svengo/docker-tor/blob/bfb9fc1a81e589748a4e94d675733d23954ff6a6/Dockerfile)
 
 Currently only the ``latest`` and the current tor version tags are supported.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Simple docker container for running a tor node.
 
 
 # Supported tags and respective `Dockerfile` links
-* [`0.4.8.6-01`, `latest`](https://github.com/svengo/docker-tor/blob/77d772d900492e16eaaf33d0228e6cadc7d99a6c/Dockerfile)
+* [`0.4.8.7-01`, `latest`](https://github.com/svengo/docker-tor/blob/bfb9fc1a81e589748a4e94d675733d23954ff6a6/Dockerfile)
 
 Currently only the ``latest`` and the current tor version tags are supported.
 


### PR DESCRIPTION
https://forum.torproject.org/t/stable-release-0-4-8-7/9398

Changes in version 0.4.8.7 - 2023-09-25

  This version fixes a single major bug in the Conflux subsystem on the client
  side. See below for more information. The upcoming Tor Browser 13 stable will
  pick this up.

  * Major bugfixes (conflux):
    * Fix an issue that prevented us from pre-building more conflux sets
      after existing sets had been used. Fixes bug 40862; bugfix
      on 0.4.8.1-alpha.

  * Minor features (fallbackdir):
    * Regenerate fallback directories generated on September 25, 2023.

  * Minor features (geoip data):
    * Update the geoip files to match the IPFire Location Database, as
      retrieved on 2023/09/25.