### PR TITLE
Tor security release 0.4.8.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.19.0
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.9
+ARG TOR_VERSION=0.4.8.10
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Simple docker container for running a tor node.
 
 
 # Supported tags and respective `Dockerfile` links
-* [`latest`](https://github.com/svengo/docker-tor/blob/a5edddc5a9960b7d9fafb0bf9fa34012641f172f/Dockerfile)
+* [`latest`](https://github.com/svengo/docker-tor/blob/963f6207aafb0172affe23fd8925686eec2136bb/Dockerfile)
 
 Currently only the `latest` tag is supported. I will be rebuilding the image on a regular basis to include updated alpine packages with important security fixes.
 


### PR DESCRIPTION
```
Changes in version 0.4.8.10 - 2023-12-08
  This is a security release fixing a high severity bug (TROVE-2023-007)
  affecting Exit relays supporting Conflux. We strongly recommend to update as
  soon as possible.

  o Major bugfixes (TROVE-2023-007, exit):
    - Improper error propagation from a safety check in conflux leg
      linking lead to a desynchronization of which legs were part of a
      conflux set, ultimately causing a UAF and NULL pointer dereference
      crash on Exit relays. Fixes bug 40897; bugfix on 0.4.8.1-alpha.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on December 08, 2023.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2023/12/08.

  o Minor bugfixes (bridges, statistics):
    - Correctly report statistics for client count over Pluggable
      transport. Fixes bug 40871; bugfix on 0.4.8.4
```