### PR TITLE
Generate additional version tag

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,6 +43,7 @@ jobs:
         flavor: | 
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
+          type=match,pattern=v(\d+\.\d+\.\d+),group=1
           type=match,pattern=v(.*),group=1
           type=sha
     -

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,7 +43,7 @@ jobs:
         flavor: | 
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
-          type=match,pattern=v(\d+\.\d+\.\d+),group=1
+          type=match,pattern=v([\d.]+),group=1
           type=match,pattern=v(.*),group=1
           type=sha
     -

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Simple docker container for running a tor node.
 
 
 # Supported tags and respective `Dockerfile` links
-* [`latest`](https://github.com/svengo/docker-tor/blob/963f6207aafb0172affe23fd8925686eec2136bb/Dockerfile)
+* [`latest`, `0.4.8.10`](https://github.com/svengo/docker-tor/blob/963f6207aafb0172affe23fd8925686eec2136bb/Dockerfile)
 
-Currently only the `latest` tag is supported. I will be rebuilding the image on a regular basis to include updated alpine packages with important security fixes.
+I will be rebuilding the image on a regular basis to include updated alpine packages with important security fixes.
 
 # How to use this image
 


### PR DESCRIPTION
Release `v1.2.3-4` generates docker tags `1.2.3` and `1.2.3-4`