### PR TITLE
Update tor to 0.4.8.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.19.1
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.10
+ARG TOR_VERSION=0.4.8.11
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Simple docker container for running a tor node.
 
 
 # Supported tags and respective `Dockerfile` links
-* [`latest`, `0.4.8.10`](https://raw.githubusercontent.com/svengo/docker-tor/7b7134975c12f5561e76c757fe9f8840d3cd53e1/Dockerfile)
+* [`latest`, `0.4.8.11`](https://github.com/svengo/docker-tor/raw/663a1916ff88e7e29d075c67ca95d5a94f203eb4/Dockerfile)
 
 I will be rebuilding the image on a regular basis to include updated alpine packages with important security fixes.
 


### PR DESCRIPTION
https://forum.torproject.org/t/stable-release-0-4-8-11/12265

Changes in version 0.4.8.11 - 2024-04-10

  This is a minor release mostly to upgrade the fallbackdir list. Worth noting
  also that directory authority running this version will now automatically
  reject relays running the end of life 0.4.7.x version.

* Minor feature (authority):
  * Reject 0.4.7.x series at the authority level. Closes ticket 40896.
* Minor feature (dirauth, tor26):
  * New IP address and keys.
*  Minor feature (directory authority):
   * Allow BandwidthFiles "node_id" KeyValue without the dollar sign at the start of the hexdigit, in order to easier database queries combining Tor documents in which the relays fingerprint does not include it. Fixes bug 40891; bugfix on 0.4.7 (all supported versions of Tor).
*  Minor features (fallbackdir):
   * Regenerate fallback directories generated on April 10, 2024.
* Minor features (geoip data):
  * Update the geoip files to match the IPFire Location Database, as retrieved on 2024/04/10.
* Minor bugfixes (directory authorities):
  * Add a warning when publishing a vote or signatures to another directory authority fails. Fixes bug 40910; bugfix on 0.2.0.3-alpha.
```
