### PR TITLE
Update to tor 0.4.8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.20.0
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.11
+ARG TOR_VERSION=0.4.8.12
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.8.11`](https://github.com/svengo/docker-tor/blob/fb8ba174ecb08419babdf58c06a9cab295c58a3d/Dockerfile)
+- [`latest`, `0.4.8.12`](https://github.com/svengo/docker-tor/blob/fb8ba174ecb08419babdf58c06a9cab295c58a3d/Dockerfile)
 
 I will regularly rebuild the image to include updated Alpine packages with important security fixes.
 


### PR DESCRIPTION
https://forum.torproject.org/t/stable-release-0-4-8-12/13060

Here is the ChangeLog.

Changes in version 0.4.8.12 - 2024-06-06
  This is a minor release with couple bugfixes affecting conflux and logging.
  We also have the return of faravahar directory authority with new keys and
  address.

- Minor feature (dirauth):
  - Add back faravahar with a new address and new keys. Closes 40689.
- Minor features (fallbackdir):
  - Regenerate fallback directories generated on June 06, 2024.
- Minor features (geoip data):
  - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2024/06/06.
- Minor bugfix (circuit):
  - Remove a log_warn being triggered by a protocol violation that
      already emits a protocol warning log. Fixes bug 40932; bugfix
      on 0.4.8.1-alpha.
- Minor bugfixes (conflux):
  - Avoid a potential hard assert (crash) when sending a cell on a
      Conflux set. Fixes bug 40921; bugfix on 0.4.8.1-alpha.
  - Make sure we don't process a closed circuit when packaging data.
      This lead to a non fatal BUG() spamming logs. Fixes bug 40908;
      bugfix on 0.4.8.1-alpha.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker container for running a Tor node to version `0.4.8.12`.
- **Documentation**
  - Updated README to reflect the new Tor node version `0.4.8.12`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->