### PR TITLE
Update anchore.yml

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -18,7 +18,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
-    - cron: '41 16 * * 4'
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC
 
 permissions:
   contents: read
@@ -34,7 +34,7 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+      run: docker build . --file Dockerfile --tag localbuild/testimage:latest --no-cache --platform linux/amd64
     - name: Run the Anchore Grype scan action
       uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
       id: scan
@@ -46,3 +46,4 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}
+        retention-days: 90


### PR DESCRIPTION
Follow advises from @coderabbitai in https://github.com/svengo/docker-tor/pull/86#pullrequestreview-2420130252:

- The current schedule (Thursday at 16:41 UTC) might not be frequent enough for security-critical Docker images. Consider running scans daily during off-peak hours to catch vulnerabilities sooner.
- Consider adding --no-cache flag to ensure fresh builds and prevent cache poisoning attacks. Also, consider adding platform specification for better reproducibility.
- Consider adding a retention period for the SARIF reports to maintain a history of security scans while managing storage efficiently.