### PR TITLE
Update anchore.yml

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -46,4 +46,3 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ steps.scan.outputs.sarif }}
-        retention-days: 90


### PR DESCRIPTION
retention-days isn't supported by the upload-sarif action, see https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job for scanning Docker images for vulnerabilities using Anchore's Grype tool.
	- Added automated vulnerability reporting with a retention period of 90 days.

- **Improvements**
	- Enhanced security by defining explicit permissions for the vulnerability scan job.
	- Configured the scan to fail the build if high-severity vulnerabilities are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->