### PR TITLE
Add separate workflow fory daily grype

### DIFF
--- a/.github/workflows/anchore-cron.yml
+++ b/.github/workflows/anchore-cron.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build the Docker image
+    - name: Pull the Docker image
       run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
     - name: Run the Anchore Grype scan action
       uses: anchore/scan-action@f2ba85e044c8f5e5014c9a539328a9c78d3bfa49

--- a/.github/workflows/anchore-cron.yml
+++ b/.github/workflows/anchore-cron.yml
@@ -9,14 +9,11 @@
 # and parameters, see https://github.com/anchore/scan-action. For more
 # information on Anchore's container image scanning tool Grype, see
 # https://github.com/anchore/grype
-name: Anchore Grype vulnerability scan
+name: Anchore Grype vulnerability scan (cron)
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC
 
 permissions:
   contents: read
@@ -31,13 +28,19 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@v4
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag localbuild/testimage:latest --no-cache --platform linux/amd64
+      run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
     - name: Run the Anchore Grype scan action
       uses: anchore/scan-action@f2ba85e044c8f5e5014c9a539328a9c78d3bfa49
       id: scan
       with:
-        image: "localbuild/testimage:latest"
+        image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
         fail-build: true
         severity-cutoff: high
     - name: Upload vulnerability report


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new automated workflow for daily vulnerability scans of Docker images using Anchore's Grype tool.
- **Improvements**
	- Removed the scheduled trigger from the existing vulnerability scan workflow, streamlining its execution for specific events only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->