### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/anchore-cron.yml
+++ b/.github/workflows/anchore-cron.yml
@@ -32,15 +32,15 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Pull the Docker image
-      run: docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
+      run: docker pull ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
     - name: Run the Anchore Grype scan action
       uses: anchore/scan-action@f2ba85e044c8f5e5014c9a539328a9c78d3bfa49
       id: scan
       with:
-        image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
+        image: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:latest
         fail-build: true
         severity-cutoff: high
     - name: Upload vulnerability report

--- a/.github/workflows/anchore-cron.yml
+++ b/.github/workflows/anchore-cron.yml
@@ -9,17 +9,17 @@
 # and parameters, see https://github.com/anchore/scan-action. For more
 # information on Anchore's container image scanning tool Grype, see
 # https://github.com/anchore/grype
-name: Anchore Grype vulnerability scan (cron)
+name: Anchore Grype daily vulnerability scan
 
 on:
   schedule:
-    - cron: '0 2 * * *'  # Daily at 2 AM UTC
+    - cron: '0 6 * * *'  # Daily at 6 AM UTC
 
 permissions:
   contents: read
 
 jobs:
-  Anchore-Build-Scan:
+  Anchore-Daily-Scan:
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -50,17 +50,15 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
-        flavor: | 
+        images: |
+          ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
+          ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}
+        flavor: |
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
-          prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}|latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
           type=match,pattern=v([\d.]+),group=1
           type=match,pattern=v(.*),group=1
           type=sha
-          type=match,pattern=v([\d.]+),group=1,prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:
-          type=match,pattern=v(.*),group=1,prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:
-          type=sha,prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:
     -
       name: Build and push Docker image
       uses: docker/build-push-action@v6

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   docker:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     steps:
     - 
@@ -50,6 +53,7 @@ jobs:
         images: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
         flavor: | 
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+          prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}|latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
           type=match,pattern=v([\d.]+),group=1
           type=match,pattern=v(.*),group=1

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -56,8 +56,9 @@ jobs:
         flavor: |
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
-          type=match,pattern=v([\d.]+),group=1
-          type=match,pattern=v(.*),group=1
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
           type=sha
     -
       name: Build and push Docker image

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -25,22 +25,22 @@ jobs:
       name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - 
       name: Update Docker Hub description
       uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-        repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
+        repository: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
         short-description: ${{ github.event.repository.description }}
     - 
       name: Build Docker meta data
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
+        images: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
         flavor: | 
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -15,10 +15,10 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-    - 
+    -
       name: Checkout
       uses: actions/checkout@v4
-    -       
+    -
       name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     -
@@ -71,7 +71,7 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64,linux/arm64
-    - 
+    -
       name: Generate job summary
       id: job-summary
       run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,14 +30,14 @@ jobs:
       with:
         username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - 
+    -
       name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - 
+    -
       name: Update Docker Hub description
       uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
       with:
@@ -45,7 +45,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
         repository: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
         short-description: ${{ github.event.repository.description }}
-    - 
+    -
       name: Build Docker meta data
       id: meta
       uses: docker/metadata-action@v5
@@ -70,6 +70,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64
     - 
       name: Generate job summary
       id: job-summary

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,6 +28,13 @@ jobs:
         username: ${{ vars.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - 
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - 
       name: Update Docker Hub description
       uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
       with:
@@ -47,6 +54,9 @@ jobs:
           type=match,pattern=v([\d.]+),group=1
           type=match,pattern=v(.*),group=1
           type=sha
+          type=match,pattern=v([\d.]+),group=1,prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:
+          type=match,pattern=v(.*),group=1,prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:
+          type=sha,prefix=ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:
     -
       name: Build and push Docker image
       uses: docker/build-push-action@v6


### PR DESCRIPTION
- Use `vars.DOCKERHUB_USERNAME`  instead of `secrets.DOCKERHUB_USERNAME`
- Also push docker image to github container registry, see https://docs.docker.com/build/ci/github-actions/push-multi-registries/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Integrated GitHub Container Registry for Docker image publishing alongside Docker Hub.
	- Introduced new tagging format for images in the GitHub Container Registry.

- **Improvements**
	- Transitioned from using secrets to variables for managing Docker Hub credentials, enhancing workflow consistency and security.
	- Added permissions for the Docker job to streamline access and operations.
	- Updated the Docker image build process to support multiple platforms (linux/amd64, linux/arm64).
	- Adjusted the schedule for daily vulnerability scans to run at 6 AM UTC.
	- Renamed and standardized job names for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->