### PR TITLE
Remove semantic versioning

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -56,10 +56,9 @@ jobs:
         flavor: |
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=semver,pattern={{major}}
-          type=sha
+          type=match,pattern=^v?((?:\d+\.){3}\d+),group=1  # 0.4.8.13
+          type=match,pattern=^v?(.*),group=1               # 0.4.8.13-docker.1
+          type=sha                                         # sha-4e91d87
     -
       name: Build and push Docker image
       uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Simple Docker container to run a Tor node.
 - **Docker Hub**:  
   [svengo/tor](https://hub.docker.com/r/svengo/tor)
 
+- **GitHub Container registry**:  
+  [svengo/docker-tor](https://github.com/svengo/docker-tor/pkgs/container/tor)
+
 - **Tor project**:  
   [Tor Project](https://www.torproject.org/)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Simple Docker container to run a Tor node.
 
 - [`latest`, `0.4.8.13`](https://github.com/svengo/docker-tor/blob/cb73f2c68feeaa2433026f2d2b00c99caaf11805/Dockerfile)
 
-I will regularly rebuild the image to include updated Alpine packages with important security fixes.
+The Docker images are tagged with the full Tor version number. Other versions are not supported.
+I will regularly rebuild the image to include updated Alpine packages with security fixes.
 
 ## How to use this image
 


### PR DESCRIPTION
- Remove semantic versioning (tried, but not working)
- reverts https://github.com/svengo/docker-tor/commit/ec164503ea426f46f895c2224e595e04c2aa272b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a link to the GitHub Container Registry for the Docker image in the README for easier access.
  
- **Chores**
	- Updated the workflow for building and publishing Docker images with improved version matching patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->