### PR TITLE
Add ghcr attestation

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,6 +13,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # permissions needed for attestations
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
     -
@@ -62,6 +65,7 @@ jobs:
     -
       name: Build and push Docker image
       uses: docker/build-push-action@v6
+      id: push
       with:
         context: .
         file: ./Dockerfile
@@ -71,6 +75,14 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64
+    - 
+      name: Attest
+      uses: actions/attest-build-provenance@v2
+      id: attest
+      with:
+        subject-name: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true
     -
       name: Generate job summary
       id: job-summary

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -75,10 +75,16 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         platforms: linux/amd64
-    - 
-      name: Attest
+    -
+      name: Attest DockerHub
       uses: actions/attest-build-provenance@v2
-      id: attest
+      with:
+        subject-name: ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true
+    -
+      name: Attest ghcr
+      uses: actions/attest-build-provenance@v2
       with:
         subject-name: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}
         subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Docker image publishing process with improved security and traceability.
	- Introduced new steps for attesting build provenance for both Docker Hub and GitHub Container Registry.
- **Permissions**
	- Updated permissions for the Docker job to include `id-token: write` and `attestations: write`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->