### PR TITLE
Revert "Update publish-docker.yml"

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -76,12 +76,17 @@ jobs:
         cache-to: type=gha,mode=max
         platforms: linux/amd64
     -
-      name: Attest Docker images
+      name: Attest DockerHub
       uses: actions/attest-build-provenance@v2
       with:
-        subject-name: |
-          docker.io/${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
-          ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}
+        subject-name: docker.io/${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}
+        subject-digest: ${{ steps.push.outputs.digest }}
+        push-to-registry: true
+    -
+      name: Attest ghcr
+      uses: actions/attest-build-provenance@v2
+      with:
+        subject-name: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}
         subject-digest: ${{ steps.push.outputs.digest }}
         push-to-registry: true
     -


### PR DESCRIPTION
Reverts svengo/docker-tor#102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new attestation step for the GitHub Container Registry (ghcr).
	- Updated Docker attestation step to focus specifically on Docker Hub.

- **Improvements**
	- Simplified input parameters for Docker Hub attestation.
	- Enhanced functionality for image provenance with new input parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->