### PR TITLE
Update/tor 0.4.8.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.21.2
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.13
+ARG TOR_VERSION=0.4.8.14
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.8.13`](https://github.com/svengo/docker-tor/blob/57a9986b8b4963f46600a1f070c67afa34660609/Dockerfile)
+- [`latest`, `0.4.8.14`](https://github.com/svengo/docker-tor/blob/8b40e1f97c4533aceb42fe72e020255214fdc90d/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
```
Changes in version 0.4.8.14 - 2025-02-05
  Minor release fixing a major bug affecting onion service directory cache,
  also known as HSDir. Furthermore, the fallbackdir list had more than 25% of
  its entries unreachable or gone from the consensus. As usual, we strongly
  recommend to update to this version as soon as possible.

  o Major bugfixes (onion service directory cache):
    - When the OOM killer kicks in, cleanup the descriptor cache of an
      HSDir by looking at the lowest downloaded count instead of time in
      cache. Fixes bug 40996; bugfix on 0.3.5.1-alpha.

  o Minor feature (testing):
    - test-network now unconditionally includes IPv6 instead of trying
      to detect IPv6 support.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on February 05, 2025.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2025/02/05.

  o Minor bugfixes (memory):
    - Fix a pointer free that wasn't set to NULL afterwards which could
      be reused by calling back in the free all function. Fixes bug
      40989; bugfix on 0.4.8.13.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker container configuration to use Tor version 0.4.8.14.
- **Documentation**
  - Revised version information to reflect the new Tor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->