### PR TITLE
Use GPG key IDs instead of e-mail adresses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   curl ${CURL_OPTIONS} "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz" && \
   curl ${CURL_OPTIONS} "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz.sha256sum" && \
   curl ${CURL_OPTIONS} "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz.sha256sum.asc" && \
-  gpg --auto-key-locate nodefault,wkd --locate-keys 514102454D0A87DB0767A1EBBE6A0531C18A9179 \
+  gpg --recv-keys 514102454D0A87DB0767A1EBBE6A0531C18A9179 \
     B74417EDDF22AC9F9E90F49142E86A2A11F48D36 \
     2133BC600AB133E1D826D173FE43009C4607B1FB && \
   sha256sum -c "tor-${TOR_VERSION}.tar.gz.sha256sum" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN \
   curl ${CURL_OPTIONS} "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz" && \
   curl ${CURL_OPTIONS} "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz.sha256sum" && \
   curl ${CURL_OPTIONS} "https://dist.torproject.org/tor-${TOR_VERSION}.tar.gz.sha256sum.asc" && \
-  gpg --auto-key-locate nodefault,wkd --locate-keys ahf@torproject.org \
-    dgoulet@torproject.org \
-    nickm@torproject.org && \
+  gpg --auto-key-locate nodefault,wkd --locate-keys 514102454D0A87DB0767A1EBBE6A0531C18A9179 \
+    B74417EDDF22AC9F9E90F49142E86A2A11F48D36 \
+    2133BC600AB133E1D826D173FE43009C4607B1FB && \
   sha256sum -c "tor-${TOR_VERSION}.tar.gz.sha256sum" && \
   gpg --verify "tor-${TOR_VERSION}.tar.gz.sha256sum.asc" && \
   tar -zxf "tor-${TOR_VERSION}.tar.gz" && \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.8.14`](https://github.com/svengo/docker-tor/blob/7ea9538e36dadbf40ee4bc1bfe6655d588480f66/Dockerfile)
+- [`latest`, `0.4.8.14`](https://github.com/svengo/docker-tor/blob/db6b47baea761351e2af56e9d5f75c930ce21d93/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.8.14`](https://github.com/svengo/docker-tor/blob/db6b47baea761351e2af56e9d5f75c930ce21d93/Dockerfile)
+- [`latest`, `0.4.8.14`](https://github.com/svengo/docker-tor/blob/3d1e2b7b5cec6b855bca307295a62792b3da9cd6/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.8.14`](https://github.com/svengo/docker-tor/blob/3d1e2b7b5cec6b855bca307295a62792b3da9cd6/Dockerfile)
+- [`latest`,`0.4.8.14`](https://github.com/svengo/docker-tor/blob/b154a499aa64384e23a444b8fccb3c0733190275/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
Use GPG keys as in https://gitlab.torproject.org/tpo/core/tor#keys-that-can-sign-a-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container build process to enhance security during package verification.

- **Documentation**
  - Revised Docker reference links in the documentation to point to the updated release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->