### PR TITLE
Update tor 0.4.8.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.21.3
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.14
+ARG TOR_VERSION=0.4.8.15
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`,`0.4.8.14`](https://github.com/svengo/docker-tor/blob/b154a499aa64384e23a444b8fccb3c0733190275/Dockerfile)
+- [`latest`,`0.4.8.15`](https://github.com/svengo/docker-tor/blob/1c24043f2a6314e0d0fc84ca2d4443f25a998e4a/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
Update to tor 0.4.8.15 - 2025-03-20

```
Changes in version 0.4.8.15 - 2025-03-20
  This is a minor release fixing a sandbox issue for bandwidth authority and a
  conflux issue on the control port. It also has a client fix about relay flag
  usage. We strongly recommend to update as soon as possible as usual.

  o Minor feature (testing, CI):
    - Use a fixed version of chutney (be881a1e) instead of its current
      HEAD. This version should also be preferred when testing locally.

  o Minor features (continuous integration):
    - Upgrade CI runners to use Debian Bookworm instead of Bullseye.
      Closes ticket 41029.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on March 20, 2025.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2025/03/20.

  o Minor bugfixes (control port):
    - Correctly report conflux pair information to controller fields
      Fixes bug 40872; bugfix on 0.4.8.1-alpha

  o Minor bugfixes (relay flag usage):
    - Fix client usage of the MiddleOnly flag so that MiddleOnly relays
      are not used as HS IP or RP by clients or services. Additionally,
      give dirauths the ability to remove specific flags, as an
      alternative to MiddleOnly. Fixes bug 41023; bugfix on 0.4.7.2-alpha

  o Minor bugfixes (sandbox, bwauth):
    - Fix sandbox to work for bandwidth authority. Fixes bug 40933;
      bugfix on 0.2.2.1-alpha
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the Docker image to use Tor version 0.4.8.15.
- **Documentation**
	- Revised the supported image tags and related links to reflect the new Tor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->