### PR TITLE
Update tor to version 0.4.8.16

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,119 @@
+language: en-US
+tone_instructions: ''
+early_access: false
+enable_free_tier: true
+auto_resolve_threads: true
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: '@coderabbitai summary'
+  high_level_summary_in_walkthrough: false
+  auto_title_placeholder: '@coderabbitai'
+  auto_title_instructions: ''
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: false
+  changed_files_summary: true
+  sequence_diagrams: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  poem: true
+  labeling_instructions: []
+  path_filters: []
+  path_instructions: []
+  abort_on_close: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords: []
+    labels: []
+    drafts: false
+    base_branches: []
+  finishing_touches:
+    docstrings:
+      enabled: true
+  tools:
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: true
+      enabled_only: false
+      level: default
+    biome:
+      enabled: true
+    hadolint:
+      enabled: true
+    swiftlint:
+      enabled: true
+    phpstan:
+      enabled: true
+      level: default
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    checkov:
+      enabled: true
+    detekt:
+      enabled: true
+    eslint:
+      enabled: true
+    rubocop:
+      enabled: true
+    buf:
+      enabled: true
+    regal:
+      enabled: true
+    actionlint:
+      enabled: true
+    pmd:
+      enabled: true
+    cppcheck:
+      enabled: true
+    semgrep:
+      enabled: true
+    circleci:
+      enabled: true
+chat:
+  auto_reply: true
+  create_issues: true
+  integrations:
+    jira:
+      usage: auto
+    linear:
+      usage: auto
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  jira:
+    usage: auto
+    project_keys: []
+  linear:
+    usage: auto
+    team_keys: []
+  pull_requests:
+    scope: auto
+code_generation:
+  docstrings:
+    language: en-US

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.21.3
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.15
+ARG TOR_VERSION=0.4.8.16
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`,`0.4.8.16`](https://github.com/svengo/docker-tor/blob/072709887aef344cb6f79d945cad3a41873b3a33/Dockerfile)
+- [`latest`, `0.4.8.16`](https://github.com/svengo/docker-tor/blob/072709887aef344cb6f79d945cad3a41873b3a33/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`,`0.4.8.15`](https://github.com/svengo/docker-tor/blob/1c24043f2a6314e0d0fc84ca2d4443f25a998e4a/Dockerfile)
+- [`latest`,`0.4.8.16`](https://github.com/svengo/docker-tor/blob/072709887aef344cb6f79d945cad3a41873b3a33/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
Update tor to version 0.4.8.16

```
Changes in version 0.4.8.16 - 2025-03-24
  This is quick second release since 0.4.8.15 due to a typo in a directory
  authority rule file. This only affects directory authorities. Regardless,
  upgrading to latest stable is always desired.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2025/03/24.

  o Minor bugfix (dirauth):
    - Fix typo in flag assignment approved-routers file. Fixes bug
      41035; bugfix on 0.4.8.15
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the Tor service dependency to version 0.4.8.16 for improved reliability.
  - Introduced a new configuration file `.coderabbit.yaml` with various settings for development environment management.
- **Documentation**
  - Revised image version details to ensure users have accurate, up-to-date information on supported Docker tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->