### PR TITLE
Bump anchore from v0.90.0 to v0.91.0

### DIFF
--- a/.github/workflows/anchore-standalone.yml
+++ b/.github/workflows/anchore-standalone.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           image: ghcr.io/${{ github.repository_owner }}/${{ vars.IMAGE_NAME }}:latest
           fail-build: false
-          grype-version: "v0.90.0"
+          grype-version: "v0.91.0"
       -
         name: Upload vulnerability report
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -58,7 +58,7 @@ jobs:
         # Fail the build for high and critical vulnerabilities
         severity-cutoff: high
         # (temporary) fix for https://github.com/anchore/scan-action/issues/451#issue-2941660915
-        grype-version: "v0.90.0"
+        grype-version: "v0.91.0"
     -
       name: Upload vulnerability report
       uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Bump anchore from v0.90.0 to v0.91.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the vulnerability scanning tool used in our CI process to version v0.91.0, ensuring enhanced scanning performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->