### PR TITLE
Remove serif upload on CI runs

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -59,8 +59,8 @@ jobs:
         severity-cutoff: high
         # (temporary) fix for https://github.com/anchore/scan-action/issues/451#issue-2941660915
         grype-version: ${{ vars.GRYPE_VERSION }}
-    -
-      name: Upload vulnerability report
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: ${{ steps.scan.outputs.sarif }}
+#    -
+#      name: Upload vulnerability report
+#      uses: github/codeql-action/upload-sarif@v3
+#      with:
+#        sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -4,8 +4,8 @@
 # documentation.
 
 # This workflow checks out code, builds an image, performs a container image
-# vulnerability scan with Anchore's Grype tool, and integrates the results with GitHub Advanced Security
-# code scanning feature.  For more information on the Anchore scan action usage
+# vulnerability scan with Anchore's Grype tool.
+# For more information on the Anchore scan action usage
 # and parameters, see https://github.com/anchore/scan-action. For more
 # information on Anchore's container image scanning tool Grype, see
 # https://github.com/anchore/grype
@@ -25,7 +25,6 @@ jobs:
   Anchore-Build-Scan:
     permissions:
       contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     runs-on: ubuntu-latest
     steps:
@@ -59,8 +58,3 @@ jobs:
         severity-cutoff: high
         # (temporary) fix for https://github.com/anchore/scan-action/issues/451#issue-2941660915
         grype-version: ${{ vars.GRYPE_VERSION }}
-#    -
-#      name: Upload vulnerability report
-#      uses: github/codeql-action/upload-sarif@v3
-#      with:
-#        sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
Remove serif upload on CI runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the upload of vulnerability reports to GitHub by eliminating the related workflow step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->