### PR TITLE
Bump tor from 0.4.8.17 to 0.4.8.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.22.1
 
 # Build-time variables
-ARG TOR_VERSION=0.4.8.17
+ARG TOR_VERSION=0.4.8.19
 ARG TZ=Europe/Berlin
 
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.8.17`](https://github.com/svengo/docker-tor/raw/f23d7ecf799c286f0421e972f080786622a878da/Dockerfile)
+- [`latest`, `0.4.8.19`](https://github.com/svengo/docker-tor/blob/117d44eeb8fdd24cec17e7b10c4b0ea45f596691/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Updated the Tor component in the container image to version 0.4.8.19; this change is applied at build time and will be included in new deployments.
  * No changes to features or user experience; existing workflows remain unchanged.
  * No action required from users; the updated image will be applied automatically during the next build/deploy cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->