### PR TITLE
Revert "Bump docker/build-push-action from 6 to 7"

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -39,7 +39,7 @@ jobs:
       uses: docker/setup-buildx-action@v4
     -
       name: Build Docker image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -64,7 +64,7 @@ jobs:
           type=sha                                         # sha-4e91d87
     -
       name: Build and push Docker image
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@v6
       id: push
       with:
         context: .


### PR DESCRIPTION
Reverts svengo/docker-tor#174

Error running [action](https://github.com/svengo/docker-tor/actions/runs/22763128959):

```
Run docker/metadata-action@v6
  with:
    images: svengo/tor
  ghcr.io/svengo/tor
  
    flavor: latest=false
  
    tags: type=match,pattern=^v?((?:\d+\.){3}\d+),group=1  # 0.4.8.13
  type=match,pattern=^v?(.*),group=1               # 0.4.8.13-docker.1
  type=sha                                         # sha-4e91d87
  
    context: workflow
    github-token: ***
Context info
  eventName: push
  sha: db7c6d894356e1a8104e125028bb4750b6183e1c
  ref: refs/heads/main
  workflow: Build and Publish Docker Image
  action: meta
  actor: svengo
  runNumber: 157
  runId: 22763128959
  commitDate: Fri Mar 06 2026 12:18:19 GMT+0000 (Coordinated Universal Time)
Processing images input
  name=svengo/tor,enable=true
  name=ghcr.io/svengo/tor,enable=true
Error: Invalid match group for type=match,pattern=^v?((?:\d+\.){3}\d+),group=1  # 0.4.8.13
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to maintain CI/CD infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->