### PR TITLE
Revert "Bump docker/metadata-action from 5 to 6"

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -51,7 +51,7 @@ jobs:
     -
       name: Build Docker meta data
       id: meta
-      uses: docker/metadata-action@v6
+      uses: docker/metadata-action@v5
       with:
         images: |
           ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}


### PR DESCRIPTION
Reverts svengo/docker-tor#173

Error running [action](https://github.com/svengo/docker-tor/actions/runs/22763128959):

```
Run docker/metadata-action@v6
  with:
    images: svengo/tor
  ghcr.io/svengo/tor
  
    flavor: latest=false
  
    tags: type=match,pattern=^v?((?:\d+\.){3}\d+),group=1  # 0.4.8.13
  type=match,pattern=^v?(.*),group=1               # 0.4.8.13-docker.1
  type=sha                                         # sha-4e91d87
  
    context: workflow
    github-token: ***
Context info
  eventName: push
  sha: db7c6d894356e1a8104e125028bb4750b6183e1c
  ref: refs/heads/main
  workflow: Build and Publish Docker Image
  action: meta
  actor: svengo
  runNumber: 157
  runId: 22763128959
  commitDate: Fri Mar 06 2026 12:18:19 GMT+0000 (Coordinated Universal Time)
Processing images input
  name=svengo/tor,enable=true
  name=ghcr.io/svengo/tor,enable=true
Error: Invalid match group for type=match,pattern=^v?((?:\d+\.){3}\d+),group=1  # 0.4.8.13
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted Docker publishing workflow dependency to a previous stable version to ensure compatibility and stability in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->