### PR TITLE
Bump tor from 0.4.9.5 to 0.4.9.6 [Security Release]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.23.3
 
 # Build-time variables
-ARG TOR_VERSION=0.4.9.5
+ARG TOR_VERSION=0.4.9.6
 
 WORKDIR /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 
 RUN \
   set -o xtrace && \
-  apk update && \
+  apk -U upgrade && \
   apk add \
     curl \
     gettext \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.9.5`](https://github.com/svengo/docker-tor/blob/e80caca7d675e6528bd4df0f8526ea9027cb7bb4/Dockerfile)
+- [`latest`, `0.4.9.6`](https://github.com/svengo/docker-tor/blob/b0e9bdcbd1bf2de9c831bb5470c2fc42bb032676/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
https://forum.torproject.org/t/security-release-0-4-8-23-and-0-4-9-6/21386

```
We just released today 0.4.8.23 and 0.4.9.6. Here is the announcement:
https://forum.torproject.org/t/security-release-0-4-8-23-and-0-4-9-6/21386

Please upgrade as soon as possible if you are running a relay.

Change log:

Changes in version 0.4.8.23 - 2026-03-25
  This is a security release fixing major bugfixes that could possibly lead to
  remote crashing relays. We strongly recommend upgrading as soon as possible.

  o Major bugfix (security, conflux):
    - Fix a memory compare using the wrong length. This could lead to a
      remote crash when using the conflux subsystem. TROVE-2026-004.
      Fixes bug 41232; bugfix on 0.4.8.1-alpha.

  o Minor bugfixes (security):
    - Fix a series of defense in depth security issues found across the
      codebase. Fixes bug 41228; bugfix on 0.3.5.1-alpha.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on March 25, 2026.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2026/03/25.

Changes in version 0.4.9.6 - 2026-03-25
  This is a security release fixing major bugfixes that could possibly lead to
  remote crashing relays. We strongly recommend upgrading as soon as possible.

  o Major bugfix (security):
    - Fix a stack overflow of 11 bytes on malicious CREATED2. This lead
      to a remote crash. TROVE-2026-003. Reported-by: Anas Cherni of
      Calif.io. Fixes bug 41231; bugfix on 0.4.9.1-alpha.

  o Major bugfix (security, conflux):
    - Fix a memory compare using the wrong length. This could lead to a
      remote crash when using the conflux subsystem. TROVE-2026-004.
      Fixes bug 41232; bugfix on 0.4.8.1-alpha.

  o Minor bugfixes (security):
    - Fix a series of defense in depth security issues found across the
      codebase. Fixes bug 41228; bugfix on 0.3.5.1-alpha.

  o Minor bugfixes (portability):
    - (Hopefully) fix our polyval implementation on big-endian
      platforms. Fixes bug 41215; bugfix on 0.4.9.3-alpha.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on March 25, 2026.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2026/03/25.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base Docker image to use Tor 0.4.9.6 (was 0.4.9.5).
  * Build process now performs an upgrade of base packages before installing dependencies.
* **Documentation**
  * Updated README tags and links to reflect the new Tor version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->