### PR TITLE
Bump tor from 0.4.9.6 to 0.4.9.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.23.4
 
 # Build-time variables
-ARG TOR_VERSION=0.4.9.6
+ARG TOR_VERSION=0.4.9.7
 
 WORKDIR /tmp
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.9.6`](https://github.com/svengo/docker-tor/blob/ec6f1938f6def8f71bdde161e15584360bb73dc9/Dockerfile)
+- [`latest`, `0.4.9.7`](https://github.com/svengo/docker-tor/blob/fa8c0ef8e9f0e236796b13851b326c6811b7d96c/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
The tor team released a security release of C-tor: 0.4.8.24 and 0.4.9.7.

Announcement:
https://forum.torproject.org/t/security-release-0-4-8-24-and-0-4-9-7/21551

```
Here is the ChangeLog (it is the same for both versions):

Changes in version 0.4.8.24 - 2026-05-06
  This is a security release fixing several major bugfixes that were reported
  in the past weeks. Huge thanks to everyone that reported these issues! We
  strongly recommend upgrading as soon as possible.

  o Major bugfixes (cell handling):
    - Fix out-of-bounds read (OOB) when END, TRUNCATE and TRUNCATED cell
      have no reason in their payload. TROVE-2026-011. Found by Brian
      Carpenter (geeknik). Fixes bug 41254; bugfix on 0.1.1.1-alpha.

  o Major bugfixes (conflux):
    - Do not attempt or accept BEGIN_DIR via conflux legs. TROVE-2026-
      008. Credit to Anas Cherni from Calif.io in collaboration with
      Claude and Anthropic Research. Fixes bug 41243; bugfix
      on 0.4.8.1-alpha.

  o Major bugfixes (conflux, relay):
    - Adjust conflux out-of-order queue accounting when clearing a
      queue. TROVE-2026-010. Found by aptupdate. Fixes bug 41251; bugfix
      on 0.4.8.1-alpha.

  o Major bugfixes (pathbias):
    - Fix a client-side crash caused by double-close of a circuit while
      under circuit queue memory pressure. TROVE-2026-009. Found by
      cypherpunks. Fixes bug 41237; bugfix on 0.3.3.6-rc.

  o Major bugfixes (relay):
    - Fix null pointer dereference when receiving a CERT cell out of
      order. TROVE-2026-006. Found by Fwame. Fixes bug 41240; bugfix
      on 0.2.4.4-alpha.

  o Major bugfixes (relay, onion service):
    - Fix off-by-one out-of-bounds read if a malformed BEGIN cell is
      received. TROVE-2026-007. Found by Flanagan. Fixes bug 41245;
      bugfix on 0.2.4.7-alpha.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on May 06, 2026.

  o Minor features (geoip data):
    - Update the geoip files to match the IPFire Location Database, as
      retrieved on 2026/05/06.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tor version to 0.4.9.7 in the Docker image build configuration.

* **Documentation**
  * Updated documentation to reflect the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->