### PR TITLE
Bump tor from 0.4.9.7 to 0.4.9.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.23.4
 
 # Build-time variables
-ARG TOR_VERSION=0.4.9.7
+ARG TOR_VERSION=0.4.9.8
 
 WORKDIR /tmp
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple Docker container to run a Tor node.
 
 ## Supported tags and corresponding `Dockerfile` links
 
-- [`latest`, `0.4.9.7`](https://github.com/svengo/docker-tor/blob/fa8c0ef8e9f0e236796b13851b326c6811b7d96c/Dockerfile)
+- [`latest`, `0.4.9.8`](https://github.com/svengo/docker-tor/blob/8b2549d51f0aa1f81cf9a5c020ac6fdfbad5135a/Dockerfile)
 
 The Docker images are tagged with the full Tor version number. Other versions are not supported.
 I will regularly rebuild the image to include updated Alpine packages with security fixes.


### PR DESCRIPTION
Due to an error in the previous releases (0.4.8.24 and 0.4.9.7), the tor team had to quickly release a new version today.

Here is the announcement: 
https://forum.torproject.org/t/security-release-0-4-8-25-and-0-4-9-8/21559

```
Changelog is below (same for both versions):

Changes in version 0.4.9.8 - 2026-05-07
  A quick second release because a silent error occurred in our CI build, which
  resulted in all fallback directories being removed from the list. This means
  that all new clients will bootstrap against the directory authorities.

  o Minor features (fallbackdir):
    - Regenerate fallback directories generated on May 07, 2026.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tor version from 0.4.9.7 to 0.4.9.8 in Docker image.
  * Updated documentation to reflect the latest Tor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->