### PR TITLE
Update Docker image tagging conditions in workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -60,8 +60,8 @@ jobs:
         flavor: |
           latest=${{ github.event_name == 'release' && github.event.release.prerelease == false }}
         tags: |
-          type=match,pattern=^v?((?:\d+\.){3}\d+),group=1,enable=${{ github.event_name == 'release' }}
-          type=match,pattern=^v?(.*),group=1,enable=${{ github.event_name == 'release' }}
+          type=match,pattern=^v?((?:\d+\.){3}\d+),group=1,enable=${{ github.event_name == 'release'  && github.event.release.prerelease == false }}
+          type=match,pattern=^v?(.*),group=1,enable=${{ github.event_name == 'release'  && github.event.release.prerelease == false }}
           type=sha
     -
       name: Build and push Docker image


### PR DESCRIPTION
Don't tag pre-releases with version number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging logic to ensure versioned tags are only created for stable releases, not pre-releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/svengo/docker-tor/pull/194)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->