### PR TITLE
Fix APK update workflow

### DIFF
--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -57,9 +57,28 @@ jobs:
           persist-credentials: false
           
       - name: Trigger rebuild
+        id: rebuild
         if: steps.check.outputs.has_updates == 'true'
         run: |
-          gh workflow run publish-docker.yml
+          set -uo pipefail
+          
+          # Get the last successful run of publish-docker.yml triggered by a release event
+          RUN_ID=$(gh run list \
+            --workflow=publish-docker.yml \
+            --status=success \
+            --event=release \
+            --limit=1 \
+            --json=databaseId \
+            --jq='.[0].databaseId')
+          
+          if [ -n "$RUN_ID" ]; then
+            echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+            gh run rerun "$RUN_ID"
+          else
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            echo "error=No successful release-triggered run found" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -96,7 +96,11 @@ jobs:
               echo "${{ steps.check.outputs.result }}"
               echo "\`\`\`"
               echo ""
-              echo "✅ Docker rebuild triggered"
+              if [ "${{ steps.rebuild.outcome }}" = "success" ]; then
+                echo "✅ Docker rebuild triggered (Run ID: ${{ steps.rebuild.outputs.run_id }})"
+              else
+                echo "❌ Failed to trigger rebuild: ${{ steps.rebuild.outputs.error }}"
+              fi
             else
               echo ""
               echo "ℹ️ No updates available"

--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -69,7 +69,8 @@ jobs:
             --event=release \
             --limit=1 \
             --json=databaseId \
-            --jq='.[0].databaseId')
+            -r \
+            --jq='.[0].databaseId // empty')
           
           if [ -n "$RUN_ID" ]; then
             echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -52,8 +52,10 @@ jobs:
 
       - name: Checkout
         if: steps.check.outputs.has_updates == 'true'
-        uses: actions/checkout@v6
-       
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+          
       - name: Trigger rebuild
         if: steps.check.outputs.has_updates == 'true'
         run: |

--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -50,6 +50,10 @@ jobs:
           echo "Available APK updates:"
           echo "${{ steps.check.outputs.result }}"
 
+      - name: Checkout
+        if: steps.check.outputs.has_updates == 'true'
+        uses: actions/checkout@v6
+       
       - name: Trigger rebuild
         if: steps.check.outputs.has_updates == 'true'
         run: |

--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -69,7 +69,6 @@ jobs:
             --event=release \
             --limit=1 \
             --json=databaseId \
-            -r \
             --jq='.[0].databaseId // empty')
           
           if [ -n "$RUN_ID" ]; then

--- a/.github/workflows/rebuild-on-apk-update.yml
+++ b/.github/workflows/rebuild-on-apk-update.yml
@@ -88,7 +88,6 @@ jobs:
           {
             echo "## APK Update Check"
             echo ""
-            echo "**Updates Found:** ${{ steps.check.outputs.has_updates }}"
             if [ "${{ steps.check.outputs.has_updates }}" = "true" ]; then
               echo ""
               echo "### Available Updates"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a conditional checkout step that runs only when APK updates are detected to support automated rebuilds.
  * Changed rebuild trigger to locate and rerun the most recent successful publish workflow started by a release event, and fail if none is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->